### PR TITLE
Install ImageMagick in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,10 @@ jobs:
           valueFile: "_config.yml"
           propertyPath: "giscus.repo"
           value: ${{ github.repository }}
+      - name: Install ImageMagick 🖼️
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter


### PR DESCRIPTION
## Summary
- ensure ImageMagick is installed before building the site

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `JEKYLL_ENV=production bundle exec jekyll build --lsi` *(fails: 403 Forbidden while fetching external posts)*

------
https://chatgpt.com/codex/tasks/task_b_688e017219248322a2bf0fd53e35644b