### PR TITLE
Add Deeper Level to building page

### DIFF
--- a/_pages/building.md
+++ b/_pages/building.md
@@ -22,6 +22,12 @@ An AI-guided system for mapping real-world risks to prediction-market hedges.
 
 ---
 
+### [Deeper Level](https://deeperlevel.xyz/)
+
+A discovery-driven text adventure where each run hides three rules, and the player learns the world well enough to escape.
+
+---
+
 ### [Mental Model Graph](/lattice-graph.html)
 
 An interactive knowledge graph connecting mental models across economics, psychology, mathematics, and logic.


### PR DESCRIPTION
## Summary
- Add Deeper Level as the third project on the building page.
- Link the entry to the live site at https://deeperlevel.xyz/.

## Test plan
- Not run; Markdown-only content update.