### PR TITLE
[codex] Improve site navigation copy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,9 +8,9 @@ middle_name:
 last_name: Zhang
 email:
 description: > # the ">" symbol means to ignore newlines until "footer_text:"
-  Weijian Zhang's personal website and writing on production AI, model behaviour, prediction markets, and decision-making.
+  Weijian Zhang's personal website and writing on production AI, model behaviour, AI product design, and decision-making.
 footer_text: >
-keywords: weijian zhang, AI, LLM evaluation, fine-tuning, prediction markets, model behaviour, decision-making # add your own keywords or leave empty
+keywords: weijian zhang, AI, LLM evaluation, fine-tuning, model behaviour, AI product design, decision-making # add your own keywords or leave empty
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: favicon.ico # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
@@ -121,7 +121,7 @@ bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
 # -----------------------------------------------------------------------------
 
 blog_name: writing # blog_name will be displayed in your blog page
-blog_description: Essays on production AI, model behaviour, prediction markets, and decision-making.
+blog_description: Essays on production AI, model behaviour, AI product design, and decision-making.
 permalink: /writing/:year/:title/
 
 # Pagination

--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,7 @@ zotero_username: # your zotero username
 wechat_qr: # filename of your wechat qr-code saved as an image (e.g., wechat-qr.png if saved to assets/img/wechat-qr.png)
 
 contact_note: >
+  For collaboration, feedback, or thoughtful disagreement, reach out on LinkedIn or X.
 
 # -----------------------------------------------------------------------------
 # Analytics and search engine verification
@@ -120,7 +121,7 @@ bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
 # -----------------------------------------------------------------------------
 
 blog_name: writing # blog_name will be displayed in your blog page
-blog_description:
+blog_description: Essays on production AI, model behaviour, prediction markets, and decision-making.
 permalink: /writing/:year/:title/
 
 # Pagination

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -14,12 +14,12 @@ social: true # includes social icons at the bottom of the page
 
 I build AI systems and evaluation loops for understanding and steering model behaviour.
 
-Currently building Tuned Tensor and Hedge Layer. I write about production AI, prediction markets, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
+Currently building Tuned Tensor and small tools for understanding model behaviour. I write about production AI, AI product design, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
 
 [Work](/building/) · [Writing](/writing/) · [Subscribe](https://notesfromzero.substack.com)
 
 ---
 
-My work sits at the intersection of production LLM systems, model evaluation and fine-tuning, AI product design, prediction-market intelligence, and the mental models needed to think clearly in fast-moving technical environments.
+My work sits at the intersection of production LLM systems, model evaluation and fine-tuning, AI product design, and the mental models needed to think clearly in fast-moving technical environments.
 
 This site is where I collect what I’m learning, building, and testing in public.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,8 +1,8 @@
 ---
 layout: about
-title: about
+title: home
 permalink: /
-subtitle: Building AI systems, evaluation loops, and small tools that make model behaviour easier to understand
+subtitle: Building AI systems and evaluation loops for understanding and steering model behaviour
 
 profile: false
 
@@ -12,9 +12,11 @@ selected_papers: false # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 ---
 
-I write about production AI, model behaviour, prediction markets, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
+I build AI systems and evaluation loops for understanding and steering model behaviour.
 
-[Subscribe on Substack →](https://notesfromzero.substack.com)
+Currently building Tuned Tensor and Hedge Layer. I write about production AI, prediction markets, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
+
+[Work](/building/) · [Writing](/writing/) · [Subscribe](https://notesfromzero.substack.com)
 
 ---
 

--- a/_pages/building.md
+++ b/_pages/building.md
@@ -12,22 +12,16 @@ nav_order: 2
 
 ### [Tuned Tensor](https://www.tunedtensor.com)
 
-Founder. Building behaviour control infrastructure for specifying model behaviour, fine-tuning open-weight models, evaluating regressions, and feeding results into the next run.
+Behaviour control infrastructure for specifying model behaviour, fine-tuning open-weight models, evaluating regressions, and feeding results into the next run.
 
 ---
 
 ### [Deeper Level](https://deeperlevel.xyz/)
 
-Experiment. A chess cognition lab where you play against a model, inspect its candidate moves, threats, inferred plan, and critique, and compare faster replies against deeper analysis.
+A chess cognition lab where you play against a model, inspect its candidate moves, threats, inferred plan, and critique, and compare faster replies against deeper analysis.
 
 ---
 
 ### [Mental Model Graph](/lattice-graph.html)
 
-Interactive tool. A knowledge graph connecting mental models across economics, psychology, mathematics, and logic.
-
----
-
-### [Still Here](https://still-here-delta.vercel.app/)
-
-Side project. A reflective web app for counting days and writing about the ones that matter.
+A knowledge graph connecting mental models across economics, psychology, mathematics, and logic.

--- a/_pages/building.md
+++ b/_pages/building.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: building
+title: work
 permalink: /building/
 nav: true
 nav_order: 2
@@ -12,28 +12,28 @@ nav_order: 2
 
 ### [Tuned Tensor](https://www.tunedtensor.com)
 
-Behaviour control infrastructure for specifying model behaviour, fine-tuning open-weight models, evaluating regressions, and feeding results into the next run.
+Founder. Building behaviour control infrastructure for specifying model behaviour, fine-tuning open-weight models, evaluating regressions, and feeding results into the next run.
 
 ---
 
 ### [Hedge Layer](https://hedgelayer.ai)
 
-Prediction-market intelligence that uses AI to research live events, discover what markets are pricing, and synthesize structured views for thesis-driven speculation.
+Founder. Building prediction-market intelligence that uses AI to research live events, discover what markets are pricing, and synthesize structured views for thesis-driven speculation.
 
 ---
 
 ### [Deeper Level](https://deeperlevel.xyz/)
 
-A chess cognition lab where you play against a model, inspect its candidate moves, threats, inferred plan, and critique, and compare faster replies against deeper analysis.
+Experiment. A chess cognition lab where you play against a model, inspect its candidate moves, threats, inferred plan, and critique, and compare faster replies against deeper analysis.
 
 ---
 
 ### [Mental Model Graph](/lattice-graph.html)
 
-An interactive knowledge graph connecting mental models across economics, psychology, mathematics, and logic.
+Interactive tool. A knowledge graph connecting mental models across economics, psychology, mathematics, and logic.
 
 ---
 
 ### [Still Here](https://still-here-delta.vercel.app/)
 
-A reflective web app for counting days and writing about the ones that matter.
+Side project. A reflective web app for counting days and writing about the ones that matter.

--- a/_pages/building.md
+++ b/_pages/building.md
@@ -16,12 +16,6 @@ Founder. Building behaviour control infrastructure for specifying model behaviou
 
 ---
 
-### [Hedge Layer](https://hedgelayer.ai)
-
-Founder. Building prediction-market intelligence that uses AI to research live events, discover what markets are pricing, and synthesize structured views for thesis-driven speculation.
-
----
-
 ### [Deeper Level](https://deeperlevel.xyz/)
 
 Experiment. A chess cognition lab where you play against a model, inspect its candidate moves, threats, inferred plan, and critique, and compare faster replies against deeper analysis.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -2,7 +2,7 @@
 layout: page
 title: projects
 permalink: /projects/
-description: Projects and experiments across AI systems, prediction markets, model behaviour, and reflective tools.
+description: Projects and experiments across AI systems, model behaviour, and reflective tools.
 nav: false
 nav_order: 2
 display_categories: [work, fun]


### PR DESCRIPTION
## Summary

This updates the personal site copy to make the homepage and primary navigation easier for new visitors to understand while keeping the public positioning focused on production AI, model behaviour, AI product design, and decision-making.

## Changes

- Renames the homepage nav label from `about` to `home`.
- Renames the `building` nav label to `work` while keeping the existing `/building/` URL stable.
- Adds clear homepage routing links for Work, Writing, and Subscribe.
- Keeps the work page focused on the current public project list.
- Adds a writing page description and a short contact note.
- Removes Hedge Layer, Still Here, and prediction-market references from public site copy/config.

## Impact

Visitors get a clearer first impression of what Weijian builds, writes about, and where to go next. Existing `/building/` links remain valid.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('_config.yml'); ['_pages/about.md','_pages/building.md','_pages/projects.md'].each { |f| s=File.read(f); y=s.split(/^---\\s*$/,3)[1]; YAML.safe_load(y) }; puts 'yaml ok'"`
- `npx prettier --check _config.yml _pages/about.md _pages/building.md _pages/projects.md`
- `ruby -e "require 'yaml'; s=File.read('_pages/building.md'); y=s.split(/^---\\s*$/,3)[1]; YAML.safe_load(y); puts 'front matter ok'"`
- `npx prettier --check _pages/building.md`

Could not run `bundle exec jekyll build` locally because the machine is using Ruby `2.6.10`, while the resolved `ffi` dependency requires Ruby `>= 3.0`.