### PR TITLE
[codex] Update homepage latest posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -182,7 +182,7 @@ announcements:
 latest_posts:
   enabled: true
   scrollable: true # adds a vertical scroll bar if there are more than 3 new posts items
-  limit: 3 # leave blank to include all the blog posts
+  limit: 6 # leave blank to include all the blog posts
 
 # -----------------------------------------------------------------------------
 # Jekyll settings

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,8 +12,6 @@ selected_papers: false # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 ---
 
-I build AI systems and evaluation loops for understanding and steering model behaviour.
-
 Currently building Tuned Tensor and small tools for understanding model behaviour. I write about production AI, AI product design, and decision-making under real-world constraints - for builders, technical leaders, and curious operators who care about substance over hype.
 
 [Work](/building/) · [Writing](/writing/) · [Subscribe](https://notesfromzero.substack.com)


### PR DESCRIPTION
## Summary

- Removes the repeated homepage intro sentence so the subtitle is not duplicated in the page body.
- Increases the homepage latest posts list from 3 items to 6 items.

## Why

The homepage repeated the same AI systems/evaluation loops line in both the subtitle and body copy. The latest posts section was also limited by the global `latest_posts.limit` config value.

## Impact

Visitors see cleaner homepage copy and a longer latest posts list.

## Validation

- Inspected the final diff for `_pages/about.md` and `_config.yml`.
- Attempted `bundle exec jekyll build`, but the local bundle did not include Jekyll.
- Attempted `bundle install` into `/tmp`, but dependency resolution failed because the current shell uses Ruby 2.6.10 and the resolved `ffi` gem requires Ruby >= 3.0.